### PR TITLE
Add support for regular expressions as from and to values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-route-transition",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A tiny transition orchestrator for React",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build:rollup": "rollup -c",
     "create-dts": "tsc --emitDeclarationOnly --declaration --declarationDir dist",
     "build": "npm run build:rollup && npm run create-dts",
-    "test": "echo \"Warning: no test specified\" && exit 0"
+    "test": "echo \"Warning: no test specified\" && exit 0",
+    "prepare": "npm run build"
   },
   "homepage": "https://github.com/dutzi/react-route-transition#readme",
   "bugs": {

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,8 @@ useTransition({
   handlers: [
     {
       // each handler can either define a path, the path can either be a
-      // string (single path), or an array of strings (multiple paths)
+      // string/regexp (single path), or an array of strings/regexps (multiple
+      // paths)
       //
       path: '/signin',
       // each handler should implement either an onEnter callback, that will

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 import * as History from 'history';
 
-export type TPathOrPaths = History.Path | History.Path[] | undefined;
+export type TPathOrPaths =
+  | History.Path
+  | RegExp
+  | (History.Path | RegExp)[]
+  | undefined;
 
 export interface ITransitionListener {
   path?: TPathOrPaths;

--- a/src/use-transition-history.ts
+++ b/src/use-transition-history.ts
@@ -4,14 +4,22 @@ import * as History from 'history';
 import { TransitionContext } from './TransitionProvider';
 
 function arrarizePath(pathOrPaths: TPathOrPaths) {
-  return typeof pathOrPaths === 'string' ? [pathOrPaths] : pathOrPaths ?? [];
+  if (typeof pathOrPaths === 'string' || pathOrPaths instanceof RegExp) {
+    return [pathOrPaths];
+  }
+
+  return pathOrPaths ?? [];
 }
 
-function removeSearch(path: History.Path) {
-  return path.split('?')[0];
+function removeSearch(path: History.Path | RegExp) {
+  if (typeof path === 'string') {
+    return path.split('?')[0];
+  }
+
+  return path;
 }
 
-function removeSearchArray(paths: History.Path[]) {
+function removeSearchArray(paths: (History.Path | RegExp)[]) {
   return paths.map(removeSearch);
 }
 
@@ -22,7 +30,23 @@ function hasPath(pathOrPaths: TPathOrPaths, path: History.Path) {
     return true;
   }
 
-  return pathsArray.indexOf(removeSearch(path)) !== -1;
+  if (
+    pathsArray
+      .filter((path) => typeof path === 'string')
+      .indexOf(removeSearch(path)) !== -1
+  ) {
+    return true;
+  }
+
+  if (
+    pathsArray
+      .filter((path) => path instanceof RegExp)
+      .find((currentPath) => (currentPath as RegExp).test(path))
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 export default function () {


### PR DESCRIPTION
This PR addresses https://github.com/dutzi/react-route-transition/issues/1.

With it, `to` and `from` will also support Regular Expressions, for example, setting `to` to:

```js
to: /\/foo\/?.*?\/bar
```

Will match against: `/foo/any-param/bar` (and also `foo/bar`).

As before, with strings, you can also pass those regular expressions in an array, mixed with string paths:

```js
to: [/\/foo\/?.*?\/bar, '/some-other-path']
```